### PR TITLE
Font menu

### DIFF
--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -7,6 +7,7 @@ import Styled from './Navbar.styled';
 import arrowIcon from '../../assets/images/icon-arrow-down.svg';
 import { useState } from 'react';
 import { Container } from '../../styles/utils/Container.styled';
+import useOutsideClick from '../../hooks/useOutsideClick';
 
 const NavBar = () => {
   const [showFontMenu, setShowFontMenu] = useState(false);
@@ -14,6 +15,7 @@ const NavBar = () => {
   const setFont = useFontActionContext();
   const setTheme = useThemeActionContext();
   const theme = useThemeContext();
+  const menu = useOutsideClick(() => setShowFontMenu(false));
 
   const changeFont = (fontSelection: Fonts) => {
     console.log(fontSelection, font);
@@ -30,7 +32,7 @@ const NavBar = () => {
           <img src={bookLogo} alt="website logo" />
         </Styled.Logo>
 
-        <Styled.FontSelectionContainer>
+        <Styled.FontSelectionContainer ref={menu}>
           <Styled.FontButton
             showFontMenu={showFontMenu}
             aria-controls="font-select"

--- a/src/components/NavBar/Navbar.styled.tsx
+++ b/src/components/NavBar/Navbar.styled.tsx
@@ -80,6 +80,8 @@ const ThemeToggle = styled.div<ThemeToggleProps>`
 const FontSelectionContainer = styled.div`
   position: relative;
   margin-right: 1.7rem;
+  z-index: 2;
+  isolation: isolate;
 
   &::after {
     content: '';

--- a/src/hooks/useOutsideClick.tsx
+++ b/src/hooks/useOutsideClick.tsx
@@ -1,0 +1,20 @@
+import { useRef, useEffect } from 'react';
+
+const useOutsideClick = (action: () => void) => {
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  const handleClickOutside = (event: MouseEvent) => {
+    if (ref.current && !ref.current.contains(event.target as HTMLDivElement)) {
+      action();
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  return ref;
+};
+
+export default useOutsideClick;


### PR DESCRIPTION
Fix the font menu from appearing under the input text. 
If user clicks outside the font menu when open, the menu will close. 